### PR TITLE
new ss(nm)g splits

### DIFF
--- a/rules.typ
+++ b/rules.typ
@@ -998,6 +998,18 @@ H.1.2) In set seed runs, intentional prerotation (spawning into the world rotate
 9.1.3) Clarification: There are no specific subcategory rules; thus, runs should only follow their respective rulesets (universal, set seed/random seed, glitched).\
 9.1.4) All random seed categories begin upon world load, whereas all set seed categories begin upon first input.
 
+= 10: Combined Any% Glitchless
+
+== 10.1: Combined Any% Glitchless Clarifications
+#formatNote[10.1.note) Combined Any% Glitchless is a non-runnable (non-submittable) category that serves as an updated statistic summing the runner's fastest verified times in each of the listed version splits. A bot that is occasionally run gathers each runner's fastest times and creates a submission summing these times, before truncating them to the second.]
+
+== 10.2: Set Seed/Random Seed Legacy
+10.2.1) Legacy will keep track of the fastest time a runner has in 1.16+, 1.9-1.15, and Pre 1.9.
+- 10.2.1.a) Clarification: The run chosen for the 1.9-1.15 split will be the runner's fastest (or only) verified submission between 1.9-1.12 and 1.13-1.15. Likewise, the run chosen for the Pre 1.9 split will be the runner's fastest (or only) verified submission between 1.8 and Pre 1.8.
+
+== 10.3: Set Seed/Random Seed All Splits
+10.3.1) All Splits will keep track of the fastest time a runner has in 1.16+, 1.13-1.15, 1.9-1.12, 1.8, and Pre 1.8.
+
 = 11: Any% (Time Travel)
 
 11.1.1) <11.1.1> The run is considered complete under the same pretences as Any% Glitchless (see #entangledRule("1.1.1")).\

--- a/rules.typ
+++ b/rules.typ
@@ -829,10 +829,10 @@ H.1.2) In set seed runs, intentional prerotation (spawning into the world rotate
 == 1.7: Set Seed, 1.16-1.19
 1.7.1) Runs under 1:50 must submit world files, logs, and gameplay audio.
 
-== 1.8: Set Seed, 1.14-1.15
+== 1.8: Set Seed, 1.13-1.15
 1.8.1) Runs under 2:45 must submit world files and logs.
 
-== 1.9: Set Seed, 1.9-1.13
+== 1.9: Set Seed, 1.9-1.12
 1.9.1) Runs under 1:00 must submit world files and logs.
 
 == 1.10: Set Seed, 1.8
@@ -842,7 +842,7 @@ H.1.2) In set seed runs, intentional prerotation (spawning into the world rotate
 1.11.1) Runs under 4:15 must submit world files and logs.
 
 == 1.12: Set Seed, 1.20+
-1.12.1) Runs under 1:40 must submit world files, logs, and gameplay audio.
+1.12.1) Runs under 1:35 must submit world files, logs, and gameplay audio.
 
 = 2: Any%
 

--- a/rules.typ
+++ b/rules.typ
@@ -995,18 +995,6 @@ H.1.2) In set seed runs, intentional prerotation (spawning into the world rotate
 9.1.3) Clarification: There are no specific subcategory rules; thus, runs should only follow their respective rulesets (universal, set seed/random seed, glitched).\
 9.1.4) All random seed categories begin upon world load, whereas all set seed categories begin upon first input.
 
-= 10: Combined Any% Glitchless
-
-== 10.1: Combined Any% Glitchless Clarifications
-#formatNote[10.1.note) Combined Any% Glitchless is a non-runnable (non-submittable) category that serves as an updated statistic summing the runner's fastest verified times in each of the listed version splits. A bot that is occasionally run gathers each runner's fastest times and creates a submission summing these times, before truncating them to the second.]
-
-== 10.2: Set Seed/Random Seed Legacy
-10.2.1) Legacy will keep track of the fastest time a runner has in 1.16+, 1.9-1.15, and Pre 1.9.
-- 10.2.1.a) Clarification: The run chosen for the 1.9-1.15 split will be the runner's fastest (or only) verified submission between 1.9-1.12 and 1.13-1.15. Likewise, the run chosen for the Pre 1.9 split will be the runner's fastest (or only) verified submission between 1.8 and Pre 1.8.
-
-== 10.3: Set Seed/Random Seed All Splits
-10.3.1) All Splits will keep track of the fastest time a runner has in 1.16+, 1.13-1.15, 1.9-1.12, 1.8, and Pre 1.8.
-
 = 11: Any% (Time Travel)
 
 11.1.1) <11.1.1> The run is considered complete under the same pretences as Any% Glitchless (see #entangledRule("1.1.1")).\

--- a/rules.typ
+++ b/rules.typ
@@ -842,7 +842,7 @@ H.1.2) In set seed runs, intentional prerotation (spawning into the world rotate
 1.11.1) Runs under 4:15 must submit world files and logs.
 
 == 1.12: Set Seed, 1.20+
-1.12.1) Runs under 1:45 must submit world files, logs, and gameplay audio.
+1.12.1) Runs under 1:40 must submit world files, logs, and gameplay audio.
 
 = 2: Any%
 

--- a/rules.typ
+++ b/rules.typ
@@ -826,13 +826,13 @@ H.1.2) In set seed runs, intentional prerotation (spawning into the world rotate
 1.6.2) Runs under 23 minutes must submit world files, logs, and gameplay audio.\
 1.6.3) Runs under 23 minutes will be retimed as per top-level retiming rules.
 
-== 1.7: Set Seed, 1.16+
+== 1.7: Set Seed, 1.16-1.19
 1.7.1) Runs under 1:50 must submit world files, logs, and gameplay audio.
 
-== 1.8: Set Seed, 1.13-1.15
+== 1.8: Set Seed, 1.14-1.15
 1.8.1) Runs under 2:45 must submit world files and logs.
 
-== 1.9: Set Seed, 1.9-1.12
+== 1.9: Set Seed, 1.9-1.13
 1.9.1) Runs under 1:00 must submit world files and logs.
 
 == 1.10: Set Seed, 1.8
@@ -840,6 +840,9 @@ H.1.2) In set seed runs, intentional prerotation (spawning into the world rotate
 
 == 1.11: Set Seed, Pre 1.8
 1.11.1) Runs under 4:15 must submit world files and logs.
+
+== 1.12: Set Seed, 1.20+
+1.12.1) Runs under 1:45 must submit world files, logs, and gameplay audio.
 
 = 2: Any%
 


### PR DESCRIPTION
combining 1.0-1.7 & 1.8 is tbd. it would likely encounter resistance but it's also just not comparable in popularity to any other ssg split. most everyone who has played it since 2023 but spropl, posho, spin, and imhello are the usual suspects who play every category (compare leaderboard to demo 5 split categories).